### PR TITLE
scss config

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,99 +1,156 @@
 "use strict"
 
 module.exports = {
+  "extends": "stylelint-config-recommended-scss",
   "rules": {
+    // Color:
+    "color-no-invalid-hex": true,
     "color-hex-case": "upper",
     "color-hex-length": "long",
+    "color-hex-alpha": "never",
     "color-named": "never",
-    "color-no-invalid-hex": true,
+    "color-function-notation": "legacy",
 
+    // Font-family:
+    "font-family-no-duplicate-names": true,
     "font-family-name-quotes": "always-unless-keyword",
 
-    "font-weight-notation": "named-where-possible",
+    // Named grid areas:
+    "named-grid-areas-no-invalid": true,
 
+    // Function:
     "function-calc-no-unspaced-operator": true,
-    "function-comma-space-after": "always",
-    "function-comma-space-before": "never",
     "function-linear-gradient-no-nonstandard-direction": true,
-    "function-parentheses-newline-inside": "never-multi-line",
-    "function-parentheses-space-inside": "never",
+    "function-no-unknown": null,
+    "function-url-no-scheme-relative": true,
     "function-url-quotes": "always",
-    "function-whitespace-after": "always",
+    "scss/function-no-unknown": true,
+    "scss/function-quote-no-quoted-strings-inside": true,
+    "scss/function-unquote-no-unquoted-strings-inside": true,
 
-    "number-leading-zero": "always",
-    "number-max-precision": 2,
-    "number-no-trailing-zeros": true,
-    "length-zero-no-unit": true,
-
+    // String:
     "string-no-newline": true,
+
+    // Unit:
     "unit-no-unknown": true,
-    "string-quotes": "single",
 
-    "value-no-vendor-prefix": true,
-    "value-list-comma-newline-before": "never-multi-line",
-    "value-list-comma-space-after": "always-single-line",
-    "value-list-comma-space-before": "never",
+    // Custom property:
+    "custom-property-no-missing-var-function": true,
 
+    // Property:
+    "property-no-unknown": true,
     "property-no-vendor-prefix": true,
 
-    "declaration-bang-space-after": "never",
-    "declaration-bang-space-before": "always",
-    "declaration-colon-space-after": "always-single-line",
-    "declaration-colon-space-before": "never",
-    "declaration-no-important": true,
+    // Keyframe declaration
+    "keyframe-declaration-no-important": true,
 
+    // Declaration block:
     "declaration-block-no-duplicate-properties": true,
+    "declaration-block-no-duplicate-custom-properties": true,
     "declaration-block-no-shorthand-property-overrides": true,
-    "declaration-block-semicolon-newline-after": "always",
-    "declaration-block-semicolon-newline-before": "never-multi-line",
-    "declaration-block-semicolon-space-after": "always-single-line",
-    "declaration-block-semicolon-space-before": "never",
     "declaration-block-single-line-max-declarations": 1,
-    "declaration-block-trailing-semicolon": "always",
 
-    "block-closing-brace-newline-after": "always",
-    "block-closing-brace-newline-before": "always",
+    // Block:
     "block-no-empty": true,
-    "block-opening-brace-newline-after": "always",
-    "block-opening-brace-newline-before": "always-single-line",
-    "block-opening-brace-space-before": "always",
 
-    "selector-combinator-space-after": "always",
-    "selector-combinator-space-before": "always",
-    "selector-max-specificity": "0,4,0",
-    "selector-no-vendor-prefix": true,
-    "selector-pseudo-element-colon-notation": "double",
+    // Selector:
+    "selector-pseudo-class-no-unknown": true,
+    "selector-pseudo-element-no-unknown": true,
+    "scss/selector-no-redundant-nesting-selector": true,
 
-    "selector-list-comma-newline-after": "always",
-    "selector-list-comma-newline-before": "never-multi-line",
-
-    "media-feature-colon-space-after": "always",
-    "media-feature-colon-space-before": "never",
+    // Media feature:
+    "media-feature-name-no-unknown": true,
     "media-feature-name-no-vendor-prefix": true,
-    "media-feature-range-operator-space-after": "always",
-    "media-feature-range-operator-space-before": "always",
 
-    "at-rule-empty-line-before": [
-      "always", {
-        "except": [
-          "after-same-name",
-          "first-nested"
-        ],
-        "ignore": [
-          "after-comment"
-        ]
-      }
-    ],
+    // At-rule
+    "at-rule-no-unknown": null,
+    "scss/at-rule-no-unknown": true,
     "at-rule-no-vendor-prefix": true,
 
-    "comment-empty-line-before": "always",
-    "comment-whitespace-inside": "always",
+    // Comment:
+    "comment-no-empty": null,
+    "scss/comment-no-empty": true,
 
-    "indentation": 2,
-    "max-line-length": 120,
-    "max-nesting-depth": 3,
+    // General/Sheet:
     "no-duplicate-selectors": true,
-    "no-eol-whitespace": true,
-    "no-unknown-animations": true
+    "no-empty-source": true,
+    "max-nesting-depth": 3,
+    "scss/no-duplicate-dollar-variables": true,
+    "scss/no-duplicate-mixins": true,
+    "scss/no-global-function-names": true,
+
+    // Alpha value:
+    "alpha-value-notation": "number",
+
+    // Length:
+    "length-zero-no-unit": true,
+
+    // Font weigth:
+    "font-weight-notation": "named-where-possible",
+
+    // Number:
+    "number-max-precision": 2,
+
+    // Unit:
+    "unit-disallowed-list": ["cm", "mm", "Q", "in", "pc", "pt", "ch", "lh"],
+
+    // Value:
+    "value-no-vendor-prefix": true,
+
+    // Declaration:
+    "declaration-no-important": true,
+    "scss/declaration-nested-properties": "never",
+    "scss/declaration-nested-properties-no-divided-groups": true,
+
+    // Selector:
+    "selector-attribute-quotes": "always",
+    "selector-max-specificity": "0,4,0",
+    "selector-max-universal": 1,
+    "selector-no-vendor-prefix": true,
+    "selector-pseudo-element-colon-notation": "double",
+    "no-unknown-animations": true,
+
+    // @-each
+    "scss/at-each-key-value-single-line": true,
+
+    // @-else
+    "scss/at-else-closing-brace-newline-after": "always-last-in-chain",
+
+    // @-extend
+    "scss/at-extend-no-missing-placeholder": true,
+
+    // @-function
+    "scss/at-function-parentheses-space-before": "never",
+
+    // @-if
+    "scss/at-if-closing-brace-newline-after": "always-last-in-chain",
+
+    // @-import
+    "scss/at-import-partial-extension": "never",
+
+    // @-mixin
+    "scss/at-mixin-argumentless-call-parentheses": "always",
+
+    // @-use
+    "scss/at-use-no-unnamespaced": true,
+
+    // $-variable
+    "scss/dollar-variable-colon-newline-after": "always",
+    "scss/dollar-variable-colon-space-after": "always",
+    "scss/dollar-variable-default": true,
+    "scss/dollar-variable-first-in-block": [
+      true,
+      {
+        "ignore": ["comments", "imports"],
+      }
+    ],
+    "scss/dollar-variable-no-missing-interpolation": true,
+    "scss/dollar-variable-no-namespaced-assignment": true,
+
+    // Dimension
+    "scss/dimension-no-non-numeric-values": true,
+
+    // Operator:
+    "scss/operator-no-unspaced": true,
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "remark-preset-lint-recommended": "^3.0.0"
   },
   "peerDependencies": {
-    "stylelint": ">=8.2.0"
+    "stylelint": ">=14.6.1",
+    "stylelint-config-recommended-scss": ">=6.0.0"
   },
   "scripts": {
     "lint:js": "eslint . --ignore-path .gitignore",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "remark-preset-lint-recommended": "^3.0.0"
   },
   "peerDependencies": {
-    "stylelint": ">=14.6.1",
+    "stylelint": ">=13.0.0",
     "stylelint-config-recommended-scss": ">=6.0.0"
   },
   "scripts": {


### PR DESCRIPTION
This brings the stylelint config up to date, removes [rules that are going to get deprecated](https://stylelint.io/user-guide/rules/list/#stylistic-issues). Adds support for scss and extends [stylelint-config-recommended-scss](https://github.com/stylelint-scss/stylelint-config-recommended-scss).

Adds some new rules, some for css, some for scss:

- [custom-property-no-missing-var-function](https://stylelint.io/user-guide/rules/list/custom-property-no-missing-var-function/): true
- [font-family-no-duplicate-names](https://stylelint.io/user-guide/rules/list/font-family-no-duplicate-names): true
- [function-no-unknown](https://stylelint.io/user-guide/rules/list/function-no-unknown): null
- [scss/function-no-unknown](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/function-no-unknown/README.md): true
- [named-grid-areas-no-invalid](https://stylelint.io/user-guide/rules/list/named-grid-areas-no-invalid): true
- [property-no-unknown](https://stylelint.io/user-guide/rules/list/property-no-unknown): true
- [keyframe-declaration-no-important](https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important): true
- [declaration-block-no-duplicate-custom-properties](https://stylelint.io/user-guide/rules/list/declaration-block-no-duplicate-custom-properties): true
- [selector-pseudo-class-no-unknown](https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown): true
- [selector-pseudo-element-no-unknown](https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown): true
- [media-feature-name-no-unknown](https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown): true
- [scss/at-each-key-value-single-line](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-each-key-value-single-line/README.md): true
- [scss/at-else-closing-brace-newline-after](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-else-closing-brace-newline-after/README.md): "always-last-in-chain"
- [scss/at-extend-no-missing-placeholder](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-extend-no-missing-placeholder/README.md): true
- [scss/at-function-parentheses-space-before](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-function-parentheses-space-before/README.md): "never"
- [scss/at-if-closing-brace-newline-after](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-if-closing-brace-newline-after/README.md): "always-last-in-chain"
- [scss/at-import-partial-extension](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-import-partial-extension/README.md): "never"
- [scss/at-mixin-argumentless-call-parentheses](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-mixin-argumentless-call-parentheses/README.md): "always"
- [scss/at-use-no-unnamespaced](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-use-no-unnamespaced/README.md): true
- [scss/dollar-variable-colon-newline-after](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dollar-variable-colon-newline-after/README.md): "always"
- [scss/dollar-variable-colon-space-after](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dollar-variable-colon-space-after/README.md): "always"
- [scss/dollar-variable-default](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dollar-variable-default/README.md): true
- [scss/dollar-variable-first-in-block](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dollar-variable-first-in-block/README.md): ```[
      true,
      {
        "ignore": ["comments", "imports"],
      }
    ]```
- [scss/dollar-variable-no-missing-interpolation](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dollar-variable-no-missing-interpolation/README.md): true
- [scss/dollar-variable-no-namespaced-assignment](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dollar-variable-no-namespaced-assignment/README.md): true
- [at-rule-no-unknown](https://stylelint.io/user-guide/rules/list/at-rule-no-unknown): null
- [scss/at-rule-no-unknown](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-rule-no-unknown/README.md): true
- [comment-no-empty](https://stylelint.io/user-guide/rules/list/comment-no-empty): null
- [scss/comment-no-empty](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/comment-no-empty/README.md): true
- [scss/declaration-nested-properties](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/declaration-nested-properties/README.md): "never"
- [scss/declaration-nested-properties-no-divided-groups](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/declaration-nested-properties-no-divided-groups/README.md): true
- [scss/dimension-no-non-numeric-values](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dimension-no-non-numeric-values/README.md): true
- [scss/function-quote-no-quoted-strings-inside](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/function-quote-no-quoted-strings-inside/README.md): true
- [scss/function-unquote-no-unquoted-strings-inside](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/function-unquote-no-unquoted-strings-inside/README.md): true
- [scss/operator-no-unspaced](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/operator-no-unspaced/README.md): true
- [alpha-value-notation](https://stylelint.io/user-guide/rules/list/alpha-value-notation): "number"
- [color-function-notation](https://stylelint.io/user-guide/rules/list/color-function-notation): "legacy"
- [color-hex-alpha](https://stylelint.io/user-guide/rules/list/color-hex-alpha): "never"
- [function-url-no-scheme-relative](https://stylelint.io/user-guide/rules/list/function-url-no-scheme-relative): true
- [unit-disallowed-list](https://stylelint.io/user-guide/rules/list/unit-disallowed-list): ["cm", "mm", "Q", "in", "pc", "pt", "ch", "lh"]
- [no-empty-source](https://stylelint.io/user-guide/rules/list/no-empty-source): true
- [scss/selector-no-redundant-nesting-selector](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/selector-no-redundant-nesting-selector/README.md): true
- [scss/no-duplicate-dollar-variables](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/no-duplicate-dollar-variables/README.md): true
- [scss/no-duplicate-mixins](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/no-duplicate-mixins/README.md): true
- [scss/no-global-function-names](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/no-global-function-names/README.md): true
- [selector-attribute-quotes](https://stylelint.io/user-guide/rules/list/selector-attribute-quotes): "always"
- [selector-max-universal](https://stylelint.io/user-guide/rules/list/selector-max-universal): 1

Removes following rules, as they are soon to be [deprecated](https://stylelint.io/user-guide/rules/list/#stylistic-issues):

- [function-comma-space-after](https://stylelint.io/user-guide/rules/list/function-comma-space-after)
- [function-comma-space-before](https://stylelint.io/user-guide/rules/list/function-comma-space-before)
- [function-parentheses-newline-inside](https://stylelint.io/user-guide/rules/list/function-parentheses-newline-inside)
- [function-parentheses-space-inside](https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside)
- [function-whitespace-after](https://stylelint.io/user-guide/rules/list/function-whitespace-after)
- [number-leading-zero](https://stylelint.io/user-guide/rules/list/number-leading-zero)
- [number-no-trailing-zeros](https://stylelint.io/user-guide/rules/list/number-no-trailing-zeros)
- [string-quotes](https://stylelint.io/user-guide/rules/list/string-quotes)
- [value-list-comma-newline-before](https://stylelint.io/user-guide/rules/list/value-list-comma-newline-before)
- [value-list-comma-space-after](https://stylelint.io/user-guide/rules/list/value-list-comma-space-after)
- [value-list-comma-space-before](https://stylelint.io/user-guide/rules/list/value-list-comma-space-before)
- [declaration-bang-space-after](https://stylelint.io/user-guide/rules/list/declaration-bang-space-after)
- [declaration-bang-space-before](https://stylelint.io/user-guide/rules/list/declaration-bang-space-before)
- [declaration-colon-space-after](https://stylelint.io/user-guide/rules/list/declaration-colon-space-after)
- [declaration-colon-space-before](https://stylelint.io/user-guide/rules/list/declaration-colon-space-before)
- [declaration-block-semicolon-newline-after](https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-after)
- [declaration-block-semicolon-newline-before](https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-before)
- [declaration-block-semicolon-space-after](https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-after)
- [declaration-block-semicolon-space-before](https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-before)
- [declaration-block-trailing-semicolon](https://stylelint.io/user-guide/rules/list/declaration-block-trailing-semicolon)
- [block-closing-brace-newline-after](https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after)
- [block-closing-brace-newline-before](https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-before)
- [block-opening-brace-newline-after](https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-after)
- [block-opening-brace-newline-before](https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-before)
- [block-opening-brace-space-before](https://stylelint.io/user-guide/rules/list/block-opening-brace-space-before)
- [selector-combinator-space-after](https://stylelint.io/user-guide/rules/list/selector-combinator-space-after)
- [selector-combinator-space-before](https://stylelint.io/user-guide/rules/list/selector-combinator-space-before)
- [selector-list-comma-newline-after](https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after)
- [selector-list-comma-newline-before](https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-before)
- [media-feature-colon-space-after](https://stylelint.io/user-guide/rules/list/media-feature-colon-space-after)
- [media-feature-colon-space-before](https://stylelint.io/user-guide/rules/list/media-feature-colon-space-before)
- [media-feature-range-operator-space-after](https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after)
- [media-feature-range-operator-space-before](https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before)
- [at-rule-empty-line-before](https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before)
- [comment-empty-line-before](https://stylelint.io/user-guide/rules/list/comment-empty-line-before)
- [comment-whitespace-inside](https://stylelint.io/user-guide/rules/list/comment-whitespace-inside)
- [indentation](https://stylelint.io/user-guide/rules/list/indentation)
- [max-line-length](https://stylelint.io/user-guide/rules/list/max-line-length)
- [no-eol-whitespace](https://stylelint.io/user-guide/rules/list/no-eol-whitespace)

Above should be taken care of by the formatter, not the linter.

I also grouped the rules based on groups they belong to in their respective documentations at [stylelint.io](https://stylelint.io/user-guide/rules/list) and [stylelint-scss](https://github.com/stylelint-scss/stylelint-scss).

As mentioned earlier, [stylelint-config-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss) is now inherited, including some [rules](https://github.com/stylelint-scss/stylelint-config-standard-scss/blob/main/index.js) of its own.

Some scss rules conflict with non-scss rules (such as at-rule-no-unknown, scss/at-rule-no-unknown), so the config has effectivelly become scss only.

There are also some rules which should be considered, such as custom-property-pattern which would allow one to force naming convention for custom properties - think similarly to naming convention enforced on Angular components. Though these should be added by a script of sorts (one which would be part of this package), which could then edit any stylelint configuration that imports this package. Also was thinking of something like enforcing certain units for certain properties, such as rems/ems for font-size, px for spacing related properties, unit-less values for line-height, etc...